### PR TITLE
Fix `factotum password` not printing the password

### DIFF
--- a/factotum/factotum.py
+++ b/factotum/factotum.py
@@ -189,7 +189,7 @@ def getPassword():
 			return settingsJson["game_password"]
 
 	except Exception as e:
-		print("Unable to read settings.json. Error %s" % (e))
+		return "Unable to read settings.json. Error %s" % (e)
 
 
 def rconCmd(cmd):
@@ -370,7 +370,7 @@ def factorio():
 @click.command()
 def password():
 	"""Get the server game password"""
-	return("The server password is: \"%s\" " % (getPassword()))
+	print("The server password is: \"%s\" " % (getPassword()))
 
 
 @click.argument("cmd", nargs=-1)	


### PR DESCRIPTION
During an earlier refactor, the functionality to read the password from the settings file was moved to a new function, but at the same time the click command was changed to `return` the password rather than `print` it.

This commit also returns a formatted error instead of just printing it, if one occurs.
